### PR TITLE
Add easy-to-use binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ code-shepherd
 A tool to shepherd your code through review to production.
 
 ```
-thor ard:pr TARGET  # Open a pull request against the target branch (master by
+ard pr TARGET  # Open a pull request against the target branch (master by
 default)
 ```

--- a/bin/ard
+++ b/bin/ard
@@ -1,5 +1,8 @@
+#!/usr/bin/env ruby
+#
 require 'bundler/setup'
 Bundler.require
+require 'thor'
 
 class Ard < Thor
   desc "pr TARGET", "Open a pull request against the target branch (master by default)"
@@ -7,3 +10,5 @@ class Ard < Thor
     Shepherd::PullRequest.new(target).open!
   end
 end
+
+Ard.start


### PR DESCRIPTION
Summary: This diff makes ard a binary, so that you can simply say

```
ard pr target
```

rather than

```
thor ard:pr target
```

and also use it in other projects.

Test Plan: dogfoodz

Reviewers:

```
@barooo plz
@gnarmis plz
@kairuiwang plz
@kochalex plz
@lshepard plz
@mpstreeter plz
@nhatch plz
@spo11 plz
@khsia plz
```
