### PR TITLE
Add easy-to-use binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ code-shepherd
 A tool to shepherd your code through review to production.
 
 ```
-thor ard:pr TARGET  # Open a pull request against the target branch (master by
+ard pr TARGET  # Open a pull request against the target branch (master by
 default)
 ```

--- a/bin/ard
+++ b/bin/ard
@@ -1,5 +1,8 @@
+#!/usr/bin/env ruby
+#
 require 'bundler/setup'
 Bundler.require
+require 'thor'
 
 class Ard < Thor
   desc "pr TARGET", "Open a pull request against the target branch (master by default)"
@@ -7,3 +10,5 @@ class Ard < Thor
     Shepherd::PullRequest.new(target).open!
   end
 end
+
+Ard.start

--- a/lib/shepherd/pull_request.rb
+++ b/lib/shepherd/pull_request.rb
@@ -23,23 +23,23 @@ module Shepherd
 
     def pr_command
       # pbcopy copies to the clipboard for easy use
-      "hub pull-request -b #{target_branch} -h #{GitBranch.current} -m \"#{contents_for_command_line}\" | pbcopy "
+      "hub pull-request -b #{target_branch} -h #{GitBranch.current} -F \"#{message.path}\" | pbcopy "
     end
 
     def differences
       GitBranch.changes(target_branch)
     end
 
-    def commit_message
-      @commit_message ||= CommitMessage.new(commit_data).acquire!
+    def message
+      @message ||= CommitMessage.new(commit_data).acquire!
     end
 
     def commit_data
       {differences: differences, target_branch: target_branch}
     end
 
-    def contents_for_command_line
-      commit_message.message_contents
+    def commit_description_path
+      message.path
     end
   end
 end

--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -39,7 +39,7 @@ module Shepherd
 
         it "executes the right command" do
           expect_any_instance_of(Object).to receive(:`).with(
-            "hub pull-request -b #{target_branch} -h #{GitBranch.current} -m \"#{contents}\" | pbcopy "
+            "hub pull-request -b #{target_branch} -h #{GitBranch.current} -F \"#{message.path}\" | pbcopy "
           )
           pr.open!
         end


### PR DESCRIPTION
Summary: This diff makes `ard` a binary, so that you can simply say

```
ard pr target
```

rather than

```
thor ard:pr target
```

and also use it in other projects.

Test Plan: dogfoodz

Reviewers:

```
@barooo plz
@gnarmis plz
@kairuiwang plz
@kochalex plz
@lshepard plz
@mpstreeter plz
@nhatch plz
@spo11 plz
@khsia plz
```
# NEW PULL REQUEST
# Describe the changes in this new PR.
# 
# Included commits between branch binarify and reviewers:
# 
# f536df4 Make it a binary
